### PR TITLE
Fix local lookup in best_match_for_query

### DIFF
--- a/API/fp.py
+++ b/API/fp.py
@@ -170,7 +170,7 @@ def best_match_for_query(code_string, elbow=10, local=False):
     if len(response.results) == 1:
         trackid = response.results[0]["track_id"]
         trackid = trackid.split("-")[0] # will work even if no `-` in trid
-        meta = metadata_for_track_id(trackid)
+        meta = metadata_for_track_id(trackid, local=local)
         if code_len - top_match_score < elbow:
             return Response(Response.SINGLE_GOOD_MATCH, TRID=trackid, score=top_match_score, qtime=response.header["QTime"], tic=tic, metadata=meta)
         else:
@@ -229,7 +229,7 @@ def best_match_for_query(code_string, elbow=10, local=False):
                 logger.info("top_score > original_scores[%s]/2 (%d > %d) GOOD_MATCH_DECREASED",
                     top_track_id, top_score, original_scores[top_track_id]/2)
                 trid = top_track_id.split("-")[0]
-                meta = metadata_for_track_id(trid)
+                meta = metadata_for_track_id(trid, local=local)
                 return Response(Response.MULTIPLE_GOOD_MATCH_HISTOGRAM_DECREASED, TRID=trid, score=top_score, qtime=response.header["QTime"], tic=tic, metadata=meta)
             else:
                 logger.info("top_score NOT > original_scores[%s]/2 (%d <= %d) BAD_HISTOGRAM_MATCH",


### PR DESCRIPTION
`metadata_for_track_id` when called from `best_match_for_query` was throwing errors in `local` mode because the flag wasn't properly being passed along – this fixes it.
