### PR TITLE
Fixed fp.delete bug and added delete ability to api.py

### DIFF
--- a/API/api.py
+++ b/API/api.py
@@ -77,9 +77,13 @@ class delete:
         params = web.input(track_ids=None)
         if params.track_ids is None:
             return web.webapi.BadRequest()
-        track_ids = params.track_ids.split(",")        
-        response = fp.delete(track_ids);
-        return json.dumps({"ok":True, "track_ids":track_ids})
+        if params.track_ids == "*":
+            fp.erase_database(True)            
+        else:            
+            track_ids = params.track_ids.split(",")        
+            fp.delete(track_ids);
+
+        return json.dumps({"ok":True, "track_ids":params.track_ids})
 
 application = web.application(urls, globals())#.wsgifunc()
         

--- a/API/api.py
+++ b/API/api.py
@@ -24,6 +24,8 @@ urls = (
     '/query', 'query',
     '/query?(.*)', 'query',
     '/ingest', 'ingest',
+    '/delete', 'delete',
+    '/delete?(.*)', 'delete'
 )
 
 
@@ -67,6 +69,17 @@ class query:
         return json.dumps({"ok":True, "query":stuff.fp_code, "message":response.message(), "match":response.match(), "score":response.score, \
                         "qtime":response.qtime, "track_id":response.TRID, "total_time":response.total_time})
 
+class delete:
+    def POST(self):
+        return self.GET()
+
+    def GET(self):
+        params = web.input(track_ids=None)
+        if params.track_ids is None:
+            return web.webapi.BadRequest()
+        track_ids = params.track_ids.split(",")        
+        response = fp.delete(track_ids);
+        return json.dumps({"ok":True, "track_ids":track_ids})
 
 application = web.application(urls, globals())#.wsgifunc()
         

--- a/API/fp.py
+++ b/API/fp.py
@@ -449,16 +449,17 @@ def delete(track_ids, do_commit=True, local=False):
         return local_delete(track_ids)
 
     with solr.pooled_connection(_fp_solr) as host:
-        for t in track_ids:
+        for t in track_ids:            
             host.delete_query("track_id:%s*" % t)
     
-    try:
+    try:            
+        track_ids = [track_id.encode("utf8") for track_id in track_ids]
         get_tyrant().multi_del(track_ids)
     except KeyError:
         pass
     
     if do_commit:
-        commit()
+        commit()        
 
 def local_erase_database():
     global _fake_solr


### PR DESCRIPTION
Was getting a UnicodeDecode error from pytyrant when using fp.delete.  Added utf8 encoding to all passed track_ids.  
Also added delete web methods to api.py. Useful for removing tracks during testing or as a rollback measure inside a multi-step ingestion process.
